### PR TITLE
Fix Usage section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Don't use for production.
 Download:
 
 ```
-go get https://github.com/agalitsyn/goapi
+go get github.com/agalitsyn/goapi
 ```
 
 ### Review settings


### PR DESCRIPTION
@agalitsyn: The Usage section in the README does not seem to work for me. Here is how it can be reproduced:

```
➜  ~ unset GOPATH
➜  ~ export GOPATH=`mktemp -d /tmp/gopath.XXXXXX`
➜  ~ echo $GOPATH
/tmp/gopath.Efh8QH
➜  ~ go get https://github.com/agalitsyn/goapi
package https:/github.com/agalitsyn/goapi: "https://" not allowed in import path
➜  ~ go get github.com/agalitsyn/goapi
➜  ~ ls $GOPATH/src/github.com/agalitsyn/goapi
Godeps	LICENSE  Makefile  Procfile  README.md	certgen  health.go  main.go  vendor  web.go  web_test.go
➜  ~
```

